### PR TITLE
[Front] MBTI 각 날짜별 레이더 차트 조회 구현

### DIFF
--- a/src/main/java/com/example/mc_front/controller/mainController.java
+++ b/src/main/java/com/example/mc_front/controller/mainController.java
@@ -30,4 +30,9 @@ public class mainController {
     public String mbtiLatest() {
         return "mbti_latest";
     }
+
+    @GetMapping("/mbti-chart")
+    public String mbtiChart() {
+        return "mbti_chart";
+    }
 }

--- a/src/main/resources/static/js/mbtiChart.js
+++ b/src/main/resources/static/js/mbtiChart.js
@@ -1,0 +1,91 @@
+// 서버에서 데이터를 가져오는 함수
+async function fetchData() {
+  const url = 'https://localhost:8443/api/mbti/chart';
+  const token = localStorage.getItem('token');  // 로컬 스토리지에서 토큰 가져오기
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token  // 헤더에 토큰 추가
+    }
+  });
+
+  const data = await response.json();
+
+  const chartData = [];
+  const chartLabels = [];
+
+  for (let item of data) {
+    const ePercent = item.e_percent;
+    const nPercent = item.n_percent;
+    const tPercent = item.t_percent;
+    const jPercent = item.j_percent;
+
+    // 각 축에 대한 점수를 계산합니다.
+    const eScore = ePercent;
+    const iScore = 100 - ePercent;
+    const nScore = nPercent;
+    const sScore = 100 - nPercent;
+    const tScore = tPercent;
+    const fScore = 100 - tPercent;
+    const jScore = jPercent;
+    const pScore = 100 - jPercent;
+
+    // 차트 데이터에 변환된 점수를 추가합니다.
+    chartData.push([iScore, eScore, sScore, nScore, fScore, tScore, pScore, jScore]);
+
+
+    // 라벨 데이터 추가
+    const dateLabel = item.reg_date.split('T')[0];
+    const resultLabel = item.result_mbti;
+    chartLabels.push(`${dateLabel} (${resultLabel})`);
+  }
+
+  drawChart(chartData, chartLabels);
+}
+
+// 데이터를 가져와 차트를 그리는 함수
+function drawChart(data, labels) {
+  const datasets = [];
+  const colors = ['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'pink', 'cyan'];
+
+  for (let i = 0; i < data.length; i++) {
+    datasets.push({
+      label: labels[i],
+      data: data[i],
+      backgroundColor: colors[i % colors.length],
+      borderColor: colors[i % colors.length],
+      borderWidth: 1,
+      fill: '-1'
+    });
+  }
+
+  const ctx = document.getElementById('mbtiChart').getContext('2d');
+  const myRadarChart = new Chart(ctx, {
+    type: 'radar',
+    data: {
+      labels: ['I', 'E', 'S', 'N', 'F', 'T', 'P', 'J'],
+      datasets: datasets
+    },
+    options: {
+      scale: {
+        ticks: {
+          beginAtZero: true,
+          max: 100,
+          stepSize: 10
+        }
+      }
+    }
+  });
+}
+
+fetchData();  // 페이지 로드 시 fetchData 호출
+
+document.querySelector('.new-mbti-btn').addEventListener('click', function() {
+  window.location.href = "/mbti-record";
+});
+
+document.querySelector('.inactive-tab').addEventListener('click', function() {
+  window.location.href = '/mbti-latest';
+});

--- a/src/main/resources/static/js/mbti_latest.js
+++ b/src/main/resources/static/js/mbti_latest.js
@@ -109,3 +109,7 @@ document.addEventListener('DOMContentLoaded', function() {
 document.querySelector('.new-mbti-btn').addEventListener('click', function() {
   window.location.href = "/mbti-record";
 });
+
+document.querySelector('.inactive-tab').addEventListener('click', function() {
+  window.location.href = '/mbti-chart';
+});

--- a/src/main/resources/templates/mbti_chart.html
+++ b/src/main/resources/templates/mbti_chart.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MBTI 변화 그래프</title>
+  <style>
+    /* 스타일링 */
+    .mbti-tab {
+      display: flex;
+      justify-content: space-between;
+
+    }
+    .active-tab {
+      border-bottom: 2px solid #1C1C1C;
+      color: #1C1C1C;
+      flex: 1; /* 화면 가로의 절반씩 차지 */
+      display: flex;
+      justify-content: center; /* 중앙 정렬 */
+      align-items: center; /* 중앙 정렬 */
+      font-size: 20px;
+      padding: 10px 0; /* 위아래로 10px 마진값 추가 */
+    }
+
+    .inactive-tab {
+      color: #999999;
+      flex: 1; /* 화면 가로의 절반씩 차지 */
+      display: flex;
+      justify-content: center; /* 중앙 정렬 */
+      align-items: center; /* 중앙 정렬 */
+      font-size: 20px;
+      padding: 10px 0; /* 위아래로 10px 마진값 추가 */
+    }
+
+    .new-mbti-btn {
+      width: 100%;
+      height: 100%;
+      padding: 16px 60px;
+      background: #16133A;
+      border-radius: 8px;
+      justify-content: center;
+      align-items: center;
+      gap: 8px;
+      display: inline-flex;
+    }
+
+    .new-mbti-text {
+      width: 199px;
+      text-align: center;
+      color: white;
+      font-size: 14px;
+      font-family: Noto Sans KR;
+      font-weight: 500;
+      word-wrap: break-word;
+    }
+
+    .chart-container {
+      width: 50%; /* 차트의 크기를 절반으로 줄임 */
+      margin: 0 auto; /* 중앙 정렬 */
+      margin-top: 50px; /* 위쪽 마진 추가 */
+      margin-bottom: 50px; /* 아래쪽 마진 추가 */
+    }
+
+    #mbtiChart {
+      max-width: 100%; /* 차트가 컨테이너보다 크지 않도록 설정 */
+      height: auto; /* 높이를 자동으로 설정 */
+    }
+
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"></script>
+</head>
+
+<body>
+<div class="mbti-tab">
+  <div class="inactive-tab">최근 MBTI</div>
+  <div class="active-tab">MBTI 변화 그래프</div>
+</div>
+
+<div class="chart-container">
+  <canvas id="mbtiChart" width="400" height="400"></canvas>
+</div>
+
+<div class="new-mbti-btn">
+  <div class="new-mbti-text">+ 새로운 <br/>MBTI 기록하기</div>
+</div>
+<script th:src="@{/static/js/mbtiChart.js}"></script>
+</body>
+
+</html>

--- a/src/main/resources/templates/mbti_latest.html
+++ b/src/main/resources/templates/mbti_latest.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Title</title>
+  <title>최근 MBTI</title>
   <style>
     /* 스타일링 */
     .mbti-display {


### PR DESCRIPTION
## 작업 내용
- [x] 서버에 날짜별 MBTI 레이더 차트 조회 요청 (이때 AccessToken을 Authorization 헤더에 포함하여 전송)
- [x] 조회된 결과를 레이더 차트 형식으로 변환
- [x] 서버에서 반환된 차트 데이터를 화면에 그래프로 표시
- [x] 서버 응답 처리 및 사용자에게 결과 표시


## 관련 이슈
Close #14 